### PR TITLE
Fix permissions bit on Docker COPY(ed) file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+add_user_to_sudoers/target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,11 @@ RUN yum update -y && yum install -y \
     # For running as a non-root user but being able to up privileges
     sudo \
     # Because VIM!
-    vim && \
+    vim \
+    # For debugging
+    strace \
+    # For tracing files in filesystem
+    tree && \
     # Cleanup
     yum clean all && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
@@ -200,6 +204,11 @@ COPY vimrc /tmp/vimrc
 COPY dracut.conf /etc/dracut.conf
 
 RUN \
+    # This is majorly stupid, but COPY does not implement any way to
+    # do something like --chmod. It also does not preserve SUID bit, so
+    # we have to set it again here...
+    chmod 4755 /usr/local/bin/add_user_to_sudoers && \
+                                                     \
     # install some nice defaults for vim and bash
     cat /tmp/vimrc >> /etc/vimrc && \
     rm /tmp/vimrc && \


### PR DESCRIPTION
It turns out that Docker's `COPY` directive in
the Dockerfile has a `--chown` option, which is good,
but they still do not have a `--chmod` flag, which
has been a request since 2017!
Because of this, the previous Docker image version
didn't get the `add_user_to_sudoers` application installed
correctly with its SUID bit set. This commit fixes that
by unfortunately having to add an additional `RUN` directive.