### PR TITLE
Add ccache setup to startup_script

### DIFF
--- a/startup_script
+++ b/startup_script
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+set -e
+
 if [ "$UID" -ne 0 ]; then
     add_user_to_sudoers
+fi
+
+if [ -n "$USE_CCACHE" ]; then
+    source scripts/setup_ccache > /dev/null
 fi
 
 exec "$@"


### PR DESCRIPTION
`setup_ccache` script will be added to lure and can setup ccache when someone does `make docker-shell USE_CCACHE=y`.

Inspired by dan's changes for quick test iteration via direct kernel booting with Transient.